### PR TITLE
Update ItemUtility.lua

### DIFF
--- a/ItemUtility.lua
+++ b/ItemUtility.lua
@@ -256,7 +256,7 @@ ItemModule["item_heavens_halberd"] = { "item_sange"; "item_talisman_of_evasion"}
 
 ItemModule["item_helm_of_the_dominator"] = { "item_helm_of_iron_will"; "item_crown"; "item_recipe_helm_of_the_dominator" }
 
-ItemModule["item_hood_of_defiance"] = { "item_ring_of_health"; "item_cloak"; "item_ring_of_regen"; "item_recipe_hood_of_defiance" }
+ItemModule["item_hood_of_defiance"] = { "item_ring_of_health"; "item_cloak"; "item_ring_of_regen" }
 
 ItemModule["item_hurricane_pike"] = { "item_dragon_lance"; "item_force_staff"; "item_recipe_hurricane_pike" }
 


### PR DESCRIPTION
Starting with 7.25, the parchment needed for item_hood_of_defiance was removed. In 7.27 return this parchment. Close this pull.