### PR TITLE
Possible variable name typo in ability_item_usage_chaos_knight

### DIFF
--- a/ability_item_usage_chaos_knight.lua
+++ b/ability_item_usage_chaos_knight.lua
@@ -90,7 +90,7 @@ local function ConsiderQ()
 				   and enemies[i]:GetAttackTarget() ~= nil
 				then
 					target = enemies[i];
-					maxAD  = estDmg;
+					maxDmg = estDmg;
 				end
 			end
 			if target ~= nil then
@@ -208,7 +208,7 @@ function AbilityUsageThink()
 	
 	castQDesire, qTarget = ConsiderQ();
 	castWDesire, wTarget = ConsiderW();
-	castRDesire	         = ConsiderR();
+	castRDesire          = ConsiderR();
 	
 	if castRDesire > 0 then
 		bot:Action_UseAbility(abilities[4]);		


### PR DESCRIPTION
I was casually looking at the code and I saw in `ability_item_usage_chaos_knight.lua:ConsiderQ` that `maxDmg` is initialized but never updated, and `maxAD` is never initialized nor tested but is updated. I believe `maxAD` should be `maxDmg`.